### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/merge_machine/labeller.py
+++ b/merge_machine/labeller.py
@@ -103,7 +103,7 @@ class Labeller():
         formated_example = ''
         for pair in self.record_pair:
             for field in self.fields:
-                line = "%s : %s" % (field, pair[field])
+                line = "{0!s} : {1!s}".format(field, pair[field])
                 formated_example += line + '\n'
             formated_example += '\n'
         return formated_example

--- a/merge_machine/preprocess_fields_v3.py
+++ b/merge_machine/preprocess_fields_v3.py
@@ -1083,19 +1083,19 @@ class CustomTelephoneMatcher(TypeMatcher):
 PRENOM_LEXICON = fileToSet('prenom')
 PATRONYME_LEXICON = fileToSet('patronyme_fr')
 
-PAT_FIRST_NAME = '(%s)' % '|'.join([p for p in PRENOM_LEXICON])
+PAT_FIRST_NAME = '({0!s})'.format('|'.join([p for p in PRENOM_LEXICON]))
 PAT_LAST_NAME = '([A-Z][A-Za-z]+\s?)+'
 PAT_LAST_NAME_ALLCAPS = '([A-Z][A-Z]+\s?)+'
 #PAT_INITIAL = '[A-Z](\.|([\.\s\-]{1,3}\s?[A-Z])+)'
 PAT_INITIAL = '([A-Z][\.\-\s]{1,3}){1,3}'
 
 # Ignore case on these two
-PAT_FIRST_LAST_NAME = '\s*%s\s+(%s)\s*' % (PAT_FIRST_NAME, PAT_LAST_NAME)
-PAT_LAST_FIRST_NAME = '\s*(%s)\s+%s\s*' % (PAT_LAST_NAME, PAT_FIRST_NAME)
+PAT_FIRST_LAST_NAME = '\s*{0!s}\s+({1!s})\s*'.format(PAT_FIRST_NAME, PAT_LAST_NAME)
+PAT_LAST_FIRST_NAME = '\s*({0!s})\s+{1!s}\s*'.format(PAT_LAST_NAME, PAT_FIRST_NAME)
 
 # Don't ignore case on those two
-PAT_FIRSTINITIAL_LAST_NAME = '\s*(%s)\s+((%s)|(%s))\s*' % (PAT_INITIAL, PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS)
-PAT_LAST_FIRSTINITIAL_NAME = '\s*((%s)|(%s))\s+(%s)\s*' % (PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS, PAT_INITIAL)
+PAT_FIRSTINITIAL_LAST_NAME = '\s*({0!s})\s+(({1!s})|({2!s}))\s*'.format(PAT_INITIAL, PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS)
+PAT_LAST_FIRSTINITIAL_NAME = '\s*(({0!s})|({1!s}))\s+({2!s})\s*'.format(PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS, PAT_INITIAL)
 
 def patternWithWordBoundary(p): return '\\b' + p + '\\b'
 
@@ -1103,10 +1103,10 @@ def reCompiledWithWordBoundary(p, flags = 0): return re.compile(patternWithWordB
 
 PERSON_NAME_EXTRACTION_PATS = [
 	(reCompiledWithWordBoundary(PAT_FIRST_NAME, re.IGNORECASE), 1, -1),
-	(reCompiledWithWordBoundary('%s\s+(%s)' % (PAT_FIRST_NAME, PAT_LAST_NAME), re.IGNORECASE), 1, 2),
-	(reCompiledWithWordBoundary('(%s)\s+%s' % (PAT_LAST_NAME, PAT_FIRST_NAME), re.IGNORECASE), 3, 1),
-	(reCompiledWithWordBoundary('(%s)\s+((%s)|(%s))' % (PAT_INITIAL, PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS)), 1, 2),
-	(reCompiledWithWordBoundary('((%s)|(%s))\s+(%s)' % (PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS, PAT_INITIAL)), 2, 1) 
+	(reCompiledWithWordBoundary('{0!s}\s+({1!s})'.format(PAT_FIRST_NAME, PAT_LAST_NAME), re.IGNORECASE), 1, 2),
+	(reCompiledWithWordBoundary('({0!s})\s+{1!s}'.format(PAT_LAST_NAME, PAT_FIRST_NAME), re.IGNORECASE), 3, 1),
+	(reCompiledWithWordBoundary('({0!s})\s+(({1!s})|({2!s}))'.format(PAT_INITIAL, PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS)), 1, 2),
+	(reCompiledWithWordBoundary('(({0!s})|({1!s}))\s+({2!s})'.format(PAT_LAST_NAME, PAT_LAST_NAME_ALLCAPS, PAT_INITIAL)), 2, 1) 
 ]
 
 def validateFirstName(fst): return len(fst) > 1
@@ -1315,7 +1315,7 @@ class FrenchAddressMatcher(LabelMatcher):
 		super(FrenchAddressMatcher, self).__init__(F_ADDRESS, COMMUNE_LEXICON, MATCH_MODE_CLOSE)
 	@timed
 	def match(self, c):
-		response = urllib.urlopen("http://api-adresse.data.gouv.fr/search/?q=%s" % c.value)
+		response = urllib.urlopen("http://api-adresse.data.gouv.fr/search/?q={0!s}".format(c.value))
 		try:
 			data = json.loads(response.read())
 		except ValueError as e: 
@@ -1526,7 +1526,7 @@ def generateValueMatchers(lvl = 0):
 			ignoreCase = False, validators = fullNameValidators)
 	yield CompositeMatcher(F_PERSON, [F_TITLE, F_FIRST])
 	# Negate person name matches when it's a street name
-	if lvl >= 0: yield RegexMatcher(F_PERSON, "(rue|avenue|av|boulevard|bvd|bd|chemin|route|place|allee) .{0,10} (%s)" % PAT_FIRST_NAME, 
+	if lvl >= 0: yield RegexMatcher(F_PERSON, "(rue|avenue|av|boulevard|bvd|bd|chemin|route|place|allee) .{{0,10}} ({0!s})".format(PAT_FIRST_NAME), 
 		g = 1, ignoreCase = True, partial = True, neg = True)
 
 	# Web stuff: Email, URL


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:eig-2017:the-magical-csv-merge-machine?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:eig-2017:the-magical-csv-merge-machine?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)