### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/merge_machine/preprocess_fields_v3.py
+++ b/merge_machine/preprocess_fields_v3.py
@@ -1285,7 +1285,7 @@ class CustomAddressMatcher(TypeMatcher):
 			return
 		parsed = parse_address(c.value)
 		if not parsed: return
-		ps = dict([(key, value) for (value, key) in parsed])
+		ps = {key: value for (value, key) in parsed}
 		v = c.value.lower()
 		comps = list()
 		for (f, lps) in LIBPOSTAL_MAPPING:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:eig-2017:the-magical-csv-merge-machine?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:eig-2017:the-magical-csv-merge-machine?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)